### PR TITLE
remove extra character in default value for direct.msgmonitor.dsnGenerator.footer

### DIFF
--- a/src/main/java/org/nhindirect/monitor/springconfig/MessageGenConfig.java
+++ b/src/main/java/org/nhindirect/monitor/springconfig/MessageGenConfig.java
@@ -45,7 +45,7 @@ public class MessageGenConfig
 	@Value("${direct.msgmonitor.dsnGenerator.header:%original_sender_tag%,<br/>}")	
 	private String header;
 	
-	@Value("${direct.msgmonitor.dsnGenerator.footer:<u>Troubleshooting Information</u></b><br/><br/>%headers_tag%å}")	
+	@Value("${direct.msgmonitor.dsnGenerator.footer:<u>Troubleshooting Information</u></b><br/><br/>%headers_tag%}")	
 	private String footer;
 	
 	@Value("${direct.msgmonitor.route.start.endpointuri:direct:start}")

--- a/src/main/java/org/nhindirect/monitor/springconfig/MessageGenConfig.java
+++ b/src/main/java/org/nhindirect/monitor/springconfig/MessageGenConfig.java
@@ -45,7 +45,7 @@ public class MessageGenConfig
 	@Value("${direct.msgmonitor.dsnGenerator.header:%original_sender_tag%,<br/>}")	
 	private String header;
 	
-	@Value("${direct.msgmonitor.dsnGenerator.footer:<u>Troubleshooting Information</u></b><br/><br/>%headers_tag%}")	
+	@Value("${direct.msgmonitor.dsnGenerator.footer:<b><u>Troubleshooting Information</u></b><br/><br/>%headers_tag%}")	
 	private String footer;
 	
 	@Value("${direct.msgmonitor.route.start.endpointuri:direct:start}")


### PR DESCRIPTION
The extra å character at the end of the default value for the property `direct.msgmonitor.dsnGenerator.footer` causes an org.jdom.IllegalDataException ("... is not legal for a JDOM character content: 0x0 is not a legal XML character").